### PR TITLE
Add manifest

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
 		</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="manifest" href="/static/manifest.json">
 	</head>
 	<body>
 		<div id="target"></div>

--- a/public/static/manifest.json
+++ b/public/static/manifest.json
@@ -1,0 +1,11 @@
+{
+  "lang": "en",
+  "short_name": "Canon Reader",
+  "name": "Canon Reader",
+  "description": "A Bible reading app that supports quick navigation, and long reading",
+  "icons": [],
+  "start_url": "https://canonreader.com/",
+  "display": "standalone",
+  "background_color": "#FAFAFA",
+  "theme_color": "#02277F"
+}


### PR DESCRIPTION
If you add canon-reader to your homescreen on a mobile device, you continue to see the browser chrome/navigation when you use canon-reader. With this commit, you should no longer be able to see the browser navigation chrome when launching from your homescreen.

(Not sure on how it works exactly on iOS. If you wanna try it out, try adding https://www.canondaily.com/ to your homescreen, as well as https://canonreader.com/, and compare the browser chrome.)

The "Theme Color" (which on Android controls the color of the status bar at the top) is set to the color of the book notch.

This will not have a great icon if you add it to your homescreen. I didn't see any icons in this repo, or I would have added them to the manifest. Maybe icons should be added before this is merged?